### PR TITLE
Switch to LifoQueues

### DIFF
--- a/grid_neural_abstractions/executors/multi_process_executor.py
+++ b/grid_neural_abstractions/executors/multi_process_executor.py
@@ -1,6 +1,7 @@
 from concurrent.futures import ProcessPoolExecutor
 from .multi_thread_executor import ExpandableAsCompleted
 import types
+from queue import LifoQueue
 
 from tqdm import tqdm  # Added tqdm for progress tracking
 
@@ -33,6 +34,8 @@ class MultiprocessExecutor:
         agg = None
 
         with ProcessPoolExecutor(max_workers=self.num_workers, initializer=local.initialize) as executor:
+            executor._work_ids = LifoQueue()
+
             with tqdm(desc="Overall Progress", smoothing=0.1) as pbar:
                 futures = []
                 for sample in samples:

--- a/grid_neural_abstractions/executors/multi_thread_executor.py
+++ b/grid_neural_abstractions/executors/multi_thread_executor.py
@@ -1,6 +1,7 @@
 from concurrent.futures import ThreadPoolExecutor
 import threading
 import time
+from queue import LifoQueue
 
 from tqdm import tqdm  # Added tqdm for progress tracking
 
@@ -171,6 +172,8 @@ class MultithreadExecutor:
         agg = None
 
         with ThreadPoolExecutor(max_workers=self.num_workers, initializer=initializer, initargs=(local,)) as executor:
+            executor._work_queue = LifoQueue()
+
             with tqdm(desc="Overall Progress", smoothing=0.1) as pbar:
                 futures = []
                 for sample in samples:

--- a/grid_neural_abstractions/executors/single_thread_executor.py
+++ b/grid_neural_abstractions/executors/single_thread_executor.py
@@ -1,6 +1,6 @@
 import types
 from tqdm import tqdm  # Added tqdm for progress tracking
-from queue import SimpleQueue
+from queue import LifoQueue
 
 
 class SinglethreadExecutor:
@@ -9,7 +9,7 @@ class SinglethreadExecutor:
         local = types.SimpleNamespace()
         initializer(local)
 
-        queue = SimpleQueue()
+        queue = LifoQueue()
         for sample in samples:
             queue.put(sample)
 


### PR DESCRIPTION
### Summary
Switch to using `LifoQueue`s to turn the search for (good) counterexamples into a DFS. This limits memory consumption and likely finds a good counterexample quicker. Note that this is not 100% exactly a DFS, since the samples are processed in parallel and when they are added to the work queue matters. 

As per discussion in #11, this could be complicated, but this PR provides a quick hack by introspection of the `ThreadPoolExecutor` and `ProcessPoolExecutor`.

### Details
_Describe in detail the changes including the reasoning._
1. In `SinglethreadExecutor`, simply replace `SimpleQueue` with `LifoQueue`.
2. In `MultithreadExecutor`, overwrite the internal variable `executor._work_queue` with a `LifoQueue`.
3. In `MultiprocessExecutor`, overwrite the internal variable `executor._work_ids` with a `LifoQueue`. The `ExecutorManagerThread` pulls the order of jobs (but not the work itself) from this queue. 

### Checks
- [ ] Close #11 
- [x] Tested Changes
