### PR TITLE
added splitting on cex

### DIFF
--- a/grid_neural_abstractions/verify_nn.py
+++ b/grid_neural_abstractions/verify_nn.py
@@ -149,7 +149,7 @@ def process_sample(
             nn_cex = network.evaluateWithMarabou([cex])[0]
             f_cex = dynamics_model(torch.tensor(cex)).flatten().numpy()
             if np.all(np.abs(nn_cex - f_cex) < epsilon):
-                split_dim = np.argmax(np.abs(nn_cex - f_cex))
+                split_dim = np.argmax(L_max[j, :] * delta)
                 sample_left, sample_right = split_sample(data, delta, split_dim)
                 return [sample_left, sample_right], []
 


### PR DESCRIPTION
Added sample splitting when a counterexample is found and the counterexample point does not violate $|NN(cex) - f(cex)| > \epsilon$

Additional changes:

Added function `split_sample` to encapsulate the logic for splitting a sample into two parts based on the split dimension.
* [`grid_neural_abstractions/verify_nn.py`](diffhunk://#diff-763ef18427f610bf95578393b6905e88e652b7ac9e2c979be89d72758ac94982L75-R75): Modified the `process_sample` function to use the new `split_sample` function for splitting samples, reducing code duplication. 
Performance enhancements:

Changed the executor from `SinglethreadExecutor` to `MultithreadExecutor` to improve the execution performance of the `verify_nn` function.
