### PR TITLE
Track the percentage of the certified domain

### DIFF
--- a/grid_neural_abstractions/executors/multi_process_executor.py
+++ b/grid_neural_abstractions/executors/multi_process_executor.py
@@ -50,9 +50,9 @@ class MultiprocessExecutor:
                 waiter = ExpandableAsCompleted(futures)
 
                 for future in waiter.as_completed():
-                    new_samples, result, certified_sample = future.result()
+                    new_samples, result, certified_samples = future.result()
                     
-                    if certified_sample:
+                    for certified_sample in certified_samples:
                         # Sample was succesfully verified, no new samples to process
                         # Update certified domain size in a thread-safe manner
                         certified_domain_size += certified_sample.calculate_size()

--- a/grid_neural_abstractions/executors/multi_thread_executor.py
+++ b/grid_neural_abstractions/executors/multi_thread_executor.py
@@ -188,9 +188,9 @@ class MultithreadExecutor:
                 waiter = ExpandableAsCompleted(futures)
 
                 for future in waiter.as_completed():
-                    new_samples, result, certified_sample = future.result()
+                    new_samples, result, certified_samples = future.result()
                     
-                    if certified_sample:
+                    for certified_sample in certified_samples:
                         # Sample was succesfully verified, no new samples to process
                         # Update certified domain size in a thread-safe manner
                         certified_domain_size += certified_sample.calculate_size()

--- a/grid_neural_abstractions/executors/single_thread_executor.py
+++ b/grid_neural_abstractions/executors/single_thread_executor.py
@@ -21,9 +21,9 @@ class SinglethreadExecutor:
                 sample = queue.get()
 
                 # Execute the batches
-                new_samples, result, certified_sample = process_sample(local, sample)
+                new_samples, result, certified_samples = process_sample(local, sample)
                 
-                if certified_sample:
+                for certified_sample in certified_samples:
                         # Sample was succesfully verified, no new samples to process
                         # Update certified domain size in a thread-safe manner
                         certified_domain_size += certified_sample.calculate_size()

--- a/grid_neural_abstractions/verify_nn.py
+++ b/grid_neural_abstractions/verify_nn.py
@@ -164,7 +164,7 @@ def process_sample(
 
             return [], [cex], []
 
-        return [], [], data  # No counterexample found, return the original sample
+        return [], [], [data]  # No counterexample found, return the original sample
 
 def split_sample(data, delta, split_dim):
     split_radius = delta[split_dim] / 2


### PR DESCRIPTION
Changes focus on calculating and displaying the certified domain size as a percentage of the total domain size during execution.
In `grid_neural_abstractions/verify_nn.py`, `process_sample` function,  we now return the sample (as a Region), when the sample has been certified.

Enhancements to progress tracking:

* [`grid_neural_abstractions/executors/multi_process_executor.py`](diffhunk://#diff-6eb5bf7a1cf122501e1c1c5f8f4a44c6d6652ab0b308a015c97a2c6e24dba184R35-R38): Added calculation of total and certified domain sizes, updated progress bar to display certified percentage. [[1]](diffhunk://#diff-6eb5bf7a1cf122501e1c1c5f8f4a44c6d6652ab0b308a015c97a2c6e24dba184R35-R38) [[2]](diffhunk://#diff-6eb5bf7a1cf122501e1c1c5f8f4a44c6d6652ab0b308a015c97a2c6e24dba184L46-R67)
* [`grid_neural_abstractions/executors/multi_thread_executor.py`](diffhunk://#diff-28501dfa869711ba324b2e6844c9da7e350c0a8d7bb62cbf304c65fd272b3b90R173-R176): Added calculation of total and certified domain sizes, updated progress bar to display certified percentage. [[1]](diffhunk://#diff-28501dfa869711ba324b2e6844c9da7e350c0a8d7bb62cbf304c65fd272b3b90R173-R176) [[2]](diffhunk://#diff-28501dfa869711ba324b2e6844c9da7e350c0a8d7bb62cbf304c65fd272b3b90L184-R206)
* [`grid_neural_abstractions/executors/single_thread_executor.py`](diffhunk://#diff-f39d4b9599ef4e8425e35017893b2cf9dcad56e02f9d0e9e0e992243e877c872R12-R15): Added calculation of total and certified domain sizes, updated progress bar to display certified percentage. [[1]](diffhunk://#diff-f39d4b9599ef4e8425e35017893b2cf9dcad56e02f9d0e9e0e992243e877c872R12-R15) [[2]](diffhunk://#diff-f39d4b9599ef4e8425e35017893b2cf9dcad56e02f9d0e9e0e992243e877c872L21-R42)

New method addition:

* [`grid_neural_abstractions/verify_nn.py`](diffhunk://#diff-763ef18427f610bf95578393b6905e88e652b7ac9e2c979be89d72758ac94982R27-R32): Added `calculate_size` method to compute the size of the region (hypercube volume).

