### PR TITLE
Fixed lower bound constraint

### DIFF
--- a/grid_neural_abstractions/verification.py
+++ b/grid_neural_abstractions/verification.py
@@ -222,7 +222,7 @@ class MarabouTaylorStrategy(VerificationStrategy):
             # Reset the query
             network.additionalEquList.clear()
 
-            # x df_c - nn_output >= epsilon + c df_c - f(c) - r_lower
+            # x df_c - nn_output >= epsilon + c df_c - f(c) - r_upper
             equation_GE = MarabouUtils.Equation(MarabouCore.Equation.GE)
             for i, inputVar in enumerate(inputVars):
                 equation_GE.addAddend(df_c_lower[j,i].item(), inputVar)
@@ -266,7 +266,7 @@ class MarabouTaylorStrategy(VerificationStrategy):
             # Reset the query
             network.additionalEquList.clear()
 
-            # x df_c - nn_output <= -epsilon - c df_c + f(c) + r_upper
+            # x df_c - nn_output <= -epsilon + c df_c - f(c) - r_lower
             equation_LE = MarabouUtils.Equation(MarabouCore.Equation.LE)            
             for i, inputVar in enumerate(inputVars):
                 # j is the output dimension, i is the input dimension, thus df_c[j,i] is the partial derivative of the j-th output with respect to the i-th input


### PR DESCRIPTION
This pull request introduces a new utility function for Taylor approximation and refines the verification logic in the `verify` method of the `VerificationStrategy` class in `grid_neural_abstractions/verification.py`. 

### IMPORTANT PATCH
we had:
$x Df(c) - N(x) \geq -\varepsilon - c Df(c) + f(c) + R$
However, it should be
$x Df(c) - N(x) \geq -\varepsilon + c Df(c) - f(c) - R$

### New Utility Function:
* Added `taylor_approximation` function to evaluate Taylor polynomial approximations at a given point. Usefull for deubbing.
